### PR TITLE
Build(publish): Only bump version for code changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Git credentials
         run: ./.github/bin/set-credentials
@@ -23,16 +25,25 @@ jobs:
       - name: Install Nim build tools
         run: ./.github/bin/install-build-tools
 
+      - name: Check if there was a code change
+        run: |
+          if git diff --name-only "$(git merge-base origin/master HEAD)" | grep '^src/.*.nim$'; then
+            echo 'NIMFILECHANGED=true' >> "${GITHUB_ENV}"
+          fi
+
       - name: Bump version and push tag
+        if:  env.NIMFILECHANGED == 'true'
         run: ./.github/bin/release
 
       - name: Build binary
         run: ./.github/bin/build
 
       - name: Export current version
+        if:  env.NIMFILECHANGED == 'true'
         run: ./.github/bin/export-version
 
       - name: Publish release
+        if:  env.NIMFILECHANGED == 'true'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I tested that this PR's approach works - see these test workflow files and logs:
- https://github.com/ee7/tooling-webserver/actions/runs/289833796/workflow (the commit doesn't have a Nim file change)
- https://github.com/ee7/tooling-webserver/actions/runs/289836882/workflow (the commit has a Nim file change)

However, this might not be the most idiomatic approach, and there might still be a bug or two.

Questions:
- What is the desired condition to push a new release? The current condition is that a Nim file changed.
- Do we want to automatically push a new release for changes in `.github/`? And if so, what is the desired version change? I noticed `overwrite: true` in the below.
https://github.com/exercism/tooling-webserver/blob/5e01be5a2642f65e5fc98f56ca054631abaa7b4c/.github/workflows/publish.yml#L35-L42

- Is this repo using semver? If so, we should probably change something with the unconditional `bump --minor` below:

https://github.com/exercism/tooling-webserver/blob/5e01be5a2642f65e5fc98f56ca054631abaa7b4c/.github/bin/release#L1-L4

Resolves: #21