### PR TITLE
Build(export-version): Avoid deprecated `set-env`

### DIFF
--- a/.github/bin/export-version
+++ b/.github/bin/export-version
@@ -2,4 +2,4 @@
 
 # Extract the version from the tooling_webserver.nimble file
 VERSION=$(nimble dump | grep "version:" | cut -d':' -f 2 | tr -d ' "')
-echo "::set-env name=VERSION::$VERSION"
+echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
(Maybe we want to merge this after finishing #23, so that a new release isn't made).

This PR is motivated by the below log warning:

The `set-env` command is deprecated and will be disabled soon. Please
upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/