### PR TITLE
Build: Enable LTO, and strip

### DIFF
--- a/.github/bin/build
+++ b/.github/bin/build
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 nimble install -d -Y
-nimble build -d:release --passC:'-flto' --passL='-static' --gcc.exe=musl-gcc --gcc.linkerexe=musl-gcc
+nimble build -d:release --passC:'-flto' --passL='-s' --passL='-static' --gcc.exe=musl-gcc --gcc.linkerexe=musl-gcc

--- a/.github/bin/build
+++ b/.github/bin/build
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 nimble install -d -Y
-nimble build -d:release --passL='-static' --gcc.exe=musl-gcc --gcc.linkerexe=musl-gcc
+nimble build -d:release --passC:'-flto' --passL='-static' --gcc.exe=musl-gcc --gcc.linkerexe=musl-gcc


### PR DESCRIPTION
(Maybe we want to merge this after finishing #23, depending on what the desired version is for a compile flag change).

Overall, this PR reduces the release binary size by 45%.

|                           | Binary size | Size ratio |
|---------------------------|------------:|-----------:|
| Before (v0.11.0, 5e01be5) |     909 KiB |       1.00 |
| LTO                       |     765 KiB |       0.84 | 
| LTO and strip (this PR)   |     502 KiB |       0.55 |

There are a few other tricks, but this is probably good enough for now. I assume that binary size isn't the most important thing (otherwise, `--opt:size` would save another 100 KiB).