### PR TITLE
Build(publish): Fix the release logic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check if there was a code change
         run: |
-          if git diff --name-only "$(git merge-base origin/master HEAD)" | grep '^src/.*.nim$'; then
+          if git diff --name-only ${{ github.event.before }} "${GITHUB_SHA}" | grep '^src/.*.nim$'; then
             echo 'NIMFILECHANGED=true' >> "${GITHUB_ENV}"
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,4 +49,4 @@ jobs:
           file: tooling_webserver
           asset_name: tooling_webserver
           tag: ${{ env.VERSION }}
-          overwrite: true
+          overwrite: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Setup Git credentials
         run: ./.github/bin/set-credentials
@@ -27,6 +25,7 @@ jobs:
 
       - name: Check if there was a code change
         run: |
+          git fetch origin ${{ github.event.before }} --depth=1
           if git diff --name-only ${{ github.event.before }} "${GITHUB_SHA}" | grep '^src/.*.nim$'; then
             echo 'NIMFILECHANGED=true' >> "${GITHUB_ENV}"
           fi


### PR DESCRIPTION
@ee7 wrote:
>  and there might still be a bug or two

This PR fixes a bug from #23 - there was no release made for https://github.com/exercism/tooling-webserver/commit/e5b8d7ea9311c728f111f4a0bab0eae16269f8fa despite a Nim code change. It's because I tested by pushing to a non-`master` branch on my fork.

This time I tested better. See the workflow runs in https://github.com/ee7/tooling-webserver/compare/e5b8d7ea9311c728f111f4a0bab0eae16269f8fa...4f5de9782df94caedc2443bfac774e98ae267caa (on my fork's `master` branch).

For the implementation at the time of writing: note that merging a Nim code change without manually bumping the version willl cause the workflow to indicate failure.

Maybe we should keep the automatic `minor` version bumping for now, and only change it after declaring 1.0.0?

Some reasons:
- All the releases so far have just bumped the `minor` version. It's a bit strange if there's suddenly a lot of `patch` bumps that have a similar (or even higher) level of change than the previous `minor` bumps. 
- Quoting https://semver.org:
> How should I deal with revisions in the 0.y.z initial development phase?
The simplest thing to do is start your initial development release at 0.1.0 and then increment the minor version for each subsequent release.

But yes, after 1.0.0 we'd have to either:
- move to manual version changes
- or change the `bump` logic so that we can control whether it runs `bump --patch`, `bump --minor` or `bump --major`. Maybe by doing something clever with the PR title/commit body, etc.
- do something else to automate it

Do we have any idea when we'd want to declare 1.0.0?