### PR TITLE
Refactor: Grab version via `nimble dump --json`

### DIFF
--- a/.github/bin/export-version
+++ b/.github/bin/export-version
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 # Extract the version from the tooling_webserver.nimble file
-VERSION=$(nimble dump | grep "version:" | cut -d':' -f 2 | tr -d ' "')
+VERSION=$(nimble dump --json | jq -r '.version')
 echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"

--- a/src/tooling_webserver.nim
+++ b/src/tooling_webserver.nim
@@ -1,7 +1,8 @@
 import std/[json, os, osproc, posix, strformat, strutils]
 import pkg/[jester, uuids]
 
-const NimblePkgVersion {.strdefine.}: string = "unknown"
+const
+  NimblePkgVersion = staticExec("nimble dump --json ../").parseJson["version"].getStr()
 
 echo fmt"Exercism Local Tooling Webhook v{NimblePkgVersion}"
 

--- a/src/tooling_webserver.nim
+++ b/src/tooling_webserver.nim
@@ -4,8 +4,6 @@ import pkg/[jester, uuids]
 const
   NimblePkgVersion = staticExec("nimble dump --json ../").parseJson["version"].getStr()
 
-echo fmt"Exercism Local Tooling Webhook v{NimblePkgVersion}"
-
 router routes:
   post "/job":
     # Create unique ID for this job
@@ -45,6 +43,8 @@ router routes:
     resp response
 
 proc main() =
+  echo fmt"Exercism Local Tooling Webhook v{NimblePkgVersion}"
+
   onSignal(SIGTERM):
     quit(0)
 


### PR DESCRIPTION
### WIP:
- [X] Rebase this PR on `master`
- [x] Merge #31

Before this PR, the version would be shown correctly when using `nimble build`, but not for `nim c tooling_webserver.nim`. It's because Nimble now passes `-d:NimblePkgVersion=x.y.z` during `nimble build`. That feature was added by [this Nimble commit](https://github.com/nim-lang/nimble/commit/4a2aaa07dc6b).

With this PR, we go via `nimble dump --json` instead. Now we can compile with a simple `nim c tooling_webserver.nim` without seeing:
```
    Exercism Local Tooling Webhook vunknown
```

The `--json` flag was added to `nimble dump` in Nim 1.4.0.

This PR also changes `export-version` to use `nimble dump --json` and `jq`, and makes a small stylistic change in the Nim code (partly to cause an automatic version bump). 